### PR TITLE
chore: version 0.1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,38 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## 0.1.4 (2021-05-22)
+
+
+### Bug Fixes
+
+* fixed typing of  packages ([57267c5](https://github.com/VLK-STUDIO/morfeo/commit/57267c5f904cbeece433e7bb2573fd9d7a4b3fd4))
+* prettier ([2c39593](https://github.com/VLK-STUDIO/morfeo/commit/2c395934ac63ba5ef7b816a3eb400ebc281298f6))
+* readme files fix and licenses added ([c71286a](https://github.com/VLK-STUDIO/morfeo/commit/c71286acf948e65eacb5e0ac808cc9425d576351))
+
+
+### Features
+
+* added pubish config to packages ([23241fc](https://github.com/VLK-STUDIO/morfeo/commit/23241fcb4a1ef76615661e5b8e9e4ed53060b912))
+* all css props mapped and styled components package improved ([c3771c6](https://github.com/VLK-STUDIO/morfeo/commit/c3771c64b02fc7bbfa6137bff70d1acae8e7932a))
+* cache and benchmarks ([aa360dd](https://github.com/VLK-STUDIO/morfeo/commit/aa360ddfb44ce2be66a0513783ddec1ff6b42e09))
+* flatted parser.resolve method ([5ce2c10](https://github.com/VLK-STUDIO/morfeo/commit/5ce2c101097b7ab28d985b108ee079e07f8bacce))
+* hooks package added ([0637789](https://github.com/VLK-STUDIO/morfeo/commit/0637789d23e12bb3dfb295039e92d2a4f815927a))
+* introucing svelte package and sandbox ([0e8e9e2](https://github.com/VLK-STUDIO/morfeo/commit/0e8e9e22f38576730c73442714c1a611847d9bc7))
+* jss package and fix to native test ([30b6c4a](https://github.com/VLK-STUDIO/morfeo/commit/30b6c4a1551ee7feb66a31c48f38e1841a6ebdb2))
+* native package ([356cbd6](https://github.com/VLK-STUDIO/morfeo/commit/356cbd6de9084be2a02db90073fb8fcbb8191641))
+* readme files added to all the packages ([819e60b](https://github.com/VLK-STUDIO/morfeo/commit/819e60bb536be471f373c8d3f7cbd5b331c1434c))
+* styled components for web ([e5dee4c](https://github.com/VLK-STUDIO/morfeo/commit/e5dee4c65277089b282b3ba7da3696451c559b83))
+* update callback to jss function ([6218907](https://github.com/VLK-STUDIO/morfeo/commit/62189076da38078df33796fb16576b13ecdeeb85))
+* useStyles hooks added ([fee9d48](https://github.com/VLK-STUDIO/morfeo/commit/fee9d48fdd60cbcc4a8ef9221df93f566371d032))
+* useSubscribe hook introduced ([8de68f2](https://github.com/VLK-STUDIO/morfeo/commit/8de68f25ed0118009d0c26c913acb6cbca697020))
+* web sandbox improvement ([d25758c](https://github.com/VLK-STUDIO/morfeo/commit/d25758c76b2769d55c8852c9f124ce1c4fe3c7b8))
+* web styled-components package introduced ([a7677c3](https://github.com/VLK-STUDIO/morfeo/commit/a7677c3a8f3c561101b0eba0b87e7fa983677cf9))
+
+
+
+
+
 ## 0.1.3 (2021-05-21)
 
 

--- a/apps/benchmarks/package.json
+++ b/apps/benchmarks/package.json
@@ -20,8 +20,8 @@
     "benchmark": "^2.1.4"
   },
   "dependencies": {
-    "@morfeo/core": "^0.1.3",
-    "@morfeo/jss": "^0.1.3",
+    "@morfeo/core": "^0.1.4",
+    "@morfeo/jss": "^0.1.4",
     "styled-system": "5.1.5"
   }
 }

--- a/apps/native-sandbox/package.json
+++ b/apps/native-sandbox/package.json
@@ -10,8 +10,8 @@
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx"
   },
   "dependencies": {
-    "@morfeo/native": "^0.1.3",
-    "@morfeo/hooks": "^0.1.3",
+    "@morfeo/native": "^0.1.4",
+    "@morfeo/hooks": "^0.1.4",
     "@types/styled-components-react-native": "^5.1.1",
     "react": "17.0.1",
     "react-native": "0.64.0",

--- a/apps/svelte-sandbox/package.json
+++ b/apps/svelte-sandbox/package.json
@@ -19,8 +19,8 @@
     "svelte": "^3.0.0"
   },
   "dependencies": {
-    "@morfeo/web": "^0.1.3",
-    "@morfeo/svelte": "^0.1.3",
+    "@morfeo/web": "^0.1.4",
+    "@morfeo/svelte": "^0.1.4",
     "rollup-plugin-replace": "^2.2.0",
     "sirv-cli": "^1.0.0"
   }

--- a/apps/web-sandbox/package.json
+++ b/apps/web-sandbox/package.json
@@ -3,9 +3,9 @@
   "version": "0.0.7",
   "private": true,
   "dependencies": {
-    "@morfeo/hooks": "^0.1.3",
-    "@morfeo/styled-components-web": "^0.1.3",
-    "@morfeo/web": "^0.1.3",
+    "@morfeo/hooks": "^0.1.4",
+    "@morfeo/styled-components-web": "^0.1.4",
+    "@morfeo/web": "^0.1.4",
     "@testing-library/jest-dom": "^5.12.0",
     "@testing-library/react": "^11.2.6",
     "@testing-library/user-event": "^12.8.3",

--- a/lerna.json
+++ b/lerna.json
@@ -2,7 +2,7 @@
   "packages": [
     "packages/*"
   ],
-  "version": "0.1.3",
+  "version": "0.1.4",
   "command": {
     "bootstrap": {
       "npmClientArgs": [

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -3,6 +3,34 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## 0.1.4 (2021-05-22)
+
+
+### Bug Fixes
+
+* fixed typing of  packages ([57267c5](https://github.com/VLK-STUDIO/morfeo/tree/main/packages/core/commit/57267c5f904cbeece433e7bb2573fd9d7a4b3fd4))
+* readme files fix and licenses added ([c71286a](https://github.com/VLK-STUDIO/morfeo/tree/main/packages/core/commit/c71286acf948e65eacb5e0ac808cc9425d576351))
+
+
+### Features
+
+* added pubish config to packages ([23241fc](https://github.com/VLK-STUDIO/morfeo/tree/main/packages/core/commit/23241fcb4a1ef76615661e5b8e9e4ed53060b912))
+* all css props mapped and styled components package improved ([c3771c6](https://github.com/VLK-STUDIO/morfeo/tree/main/packages/core/commit/c3771c64b02fc7bbfa6137bff70d1acae8e7932a))
+* cache and benchmarks ([aa360dd](https://github.com/VLK-STUDIO/morfeo/tree/main/packages/core/commit/aa360ddfb44ce2be66a0513783ddec1ff6b42e09))
+* flatted parser.resolve method ([5ce2c10](https://github.com/VLK-STUDIO/morfeo/tree/main/packages/core/commit/5ce2c101097b7ab28d985b108ee079e07f8bacce))
+* hooks package added ([0637789](https://github.com/VLK-STUDIO/morfeo/tree/main/packages/core/commit/0637789d23e12bb3dfb295039e92d2a4f815927a))
+* introucing svelte package and sandbox ([0e8e9e2](https://github.com/VLK-STUDIO/morfeo/tree/main/packages/core/commit/0e8e9e22f38576730c73442714c1a611847d9bc7))
+* native package ([356cbd6](https://github.com/VLK-STUDIO/morfeo/tree/main/packages/core/commit/356cbd6de9084be2a02db90073fb8fcbb8191641))
+* readme files added to all the packages ([819e60b](https://github.com/VLK-STUDIO/morfeo/tree/main/packages/core/commit/819e60bb536be471f373c8d3f7cbd5b331c1434c))
+* styled components for web ([e5dee4c](https://github.com/VLK-STUDIO/morfeo/tree/main/packages/core/commit/e5dee4c65277089b282b3ba7da3696451c559b83))
+* update callback to jss function ([6218907](https://github.com/VLK-STUDIO/morfeo/tree/main/packages/core/commit/62189076da38078df33796fb16576b13ecdeeb85))
+* useSubscribe hook introduced ([8de68f2](https://github.com/VLK-STUDIO/morfeo/tree/main/packages/core/commit/8de68f25ed0118009d0c26c913acb6cbca697020))
+* web styled-components package introduced ([a7677c3](https://github.com/VLK-STUDIO/morfeo/tree/main/packages/core/commit/a7677c3a8f3c561101b0eba0b87e7fa983677cf9))
+
+
+
+
+
 ## 0.1.3 (2021-05-21)
 
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -5,7 +5,7 @@
     "email": "mauro@vlkstudio.com"
   },
   "private": false,
-  "version": "0.1.3",
+  "version": "0.1.4",
   "license": "MIT",
   "main": "build/index.js",
   "module": "build/index.js",
@@ -20,7 +20,7 @@
     "watch": "tsc -w"
   },
   "dependencies": {
-    "@morfeo/spec": "^0.1.3"
+    "@morfeo/spec": "^0.1.4"
   },
   "peerDependencies": {
     "tslib": "^2.2.0"

--- a/packages/hooks/CHANGELOG.md
+++ b/packages/hooks/CHANGELOG.md
@@ -3,6 +3,31 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## 0.1.4 (2021-05-22)
+
+
+### Bug Fixes
+
+* fixed typing of  packages ([57267c5](https://github.com/VLK-STUDIO/morfeo/tree/main/packages/hooks/commit/57267c5f904cbeece433e7bb2573fd9d7a4b3fd4))
+* readme files fix and licenses added ([c71286a](https://github.com/VLK-STUDIO/morfeo/tree/main/packages/hooks/commit/c71286acf948e65eacb5e0ac808cc9425d576351))
+
+
+### Features
+
+* added pubish config to packages ([23241fc](https://github.com/VLK-STUDIO/morfeo/tree/main/packages/hooks/commit/23241fcb4a1ef76615661e5b8e9e4ed53060b912))
+* flatted parser.resolve method ([5ce2c10](https://github.com/VLK-STUDIO/morfeo/tree/main/packages/hooks/commit/5ce2c101097b7ab28d985b108ee079e07f8bacce))
+* hooks package added ([0637789](https://github.com/VLK-STUDIO/morfeo/tree/main/packages/hooks/commit/0637789d23e12bb3dfb295039e92d2a4f815927a))
+* introucing svelte package and sandbox ([0e8e9e2](https://github.com/VLK-STUDIO/morfeo/tree/main/packages/hooks/commit/0e8e9e22f38576730c73442714c1a611847d9bc7))
+* native package ([356cbd6](https://github.com/VLK-STUDIO/morfeo/tree/main/packages/hooks/commit/356cbd6de9084be2a02db90073fb8fcbb8191641))
+* readme files added to all the packages ([819e60b](https://github.com/VLK-STUDIO/morfeo/tree/main/packages/hooks/commit/819e60bb536be471f373c8d3f7cbd5b331c1434c))
+* useStyles hooks added ([fee9d48](https://github.com/VLK-STUDIO/morfeo/tree/main/packages/hooks/commit/fee9d48fdd60cbcc4a8ef9221df93f566371d032))
+* useSubscribe hook introduced ([8de68f2](https://github.com/VLK-STUDIO/morfeo/tree/main/packages/hooks/commit/8de68f25ed0118009d0c26c913acb6cbca697020))
+* web styled-components package introduced ([a7677c3](https://github.com/VLK-STUDIO/morfeo/tree/main/packages/hooks/commit/a7677c3a8f3c561101b0eba0b87e7fa983677cf9))
+
+
+
+
+
 ## 0.1.3 (2021-05-21)
 
 

--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -5,7 +5,7 @@
     "email": "mauro@vlkstudio.com"
   },
   "private": false,
-  "version": "0.1.3",
+  "version": "0.1.4",
   "license": "MIT",
   "main": "build/index.js",
   "module": "build/index.js",
@@ -20,12 +20,12 @@
     "watch": "tsc -w"
   },
   "peerDependencies": {
-    "@morfeo/core": "^0.1.3",
+    "@morfeo/core": "^0.1.4",
     "react": "17.0.2",
     "react-dom": "^17.0.2"
   },
   "devDependencies": {
-    "@morfeo/core": "^0.1.3"
+    "@morfeo/core": "^0.1.4"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/jss/CHANGELOG.md
+++ b/packages/jss/CHANGELOG.md
@@ -3,6 +3,26 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## 0.1.4 (2021-05-22)
+
+
+### Bug Fixes
+
+* readme files fix and licenses added ([c71286a](https://github.com/VLK-STUDIO/morfeo/tree/main/packages/jss/commit/c71286acf948e65eacb5e0ac808cc9425d576351))
+
+
+### Features
+
+* flatted parser.resolve method ([5ce2c10](https://github.com/VLK-STUDIO/morfeo/tree/main/packages/jss/commit/5ce2c101097b7ab28d985b108ee079e07f8bacce))
+* introucing svelte package and sandbox ([0e8e9e2](https://github.com/VLK-STUDIO/morfeo/tree/main/packages/jss/commit/0e8e9e22f38576730c73442714c1a611847d9bc7))
+* jss package and fix to native test ([30b6c4a](https://github.com/VLK-STUDIO/morfeo/tree/main/packages/jss/commit/30b6c4a1551ee7feb66a31c48f38e1841a6ebdb2))
+* readme files added to all the packages ([819e60b](https://github.com/VLK-STUDIO/morfeo/tree/main/packages/jss/commit/819e60bb536be471f373c8d3f7cbd5b331c1434c))
+* update callback to jss function ([6218907](https://github.com/VLK-STUDIO/morfeo/tree/main/packages/jss/commit/62189076da38078df33796fb16576b13ecdeeb85))
+
+
+
+
+
 ## 0.1.3 (2021-05-21)
 
 

--- a/packages/jss/package.json
+++ b/packages/jss/package.json
@@ -5,7 +5,7 @@
     "email": "mauro@vlkstudio.com"
   },
   "private": false,
-  "version": "0.1.3",
+  "version": "0.1.4",
   "license": "MIT",
   "main": "build/index.js",
   "module": "build/index.js",
@@ -25,10 +25,10 @@
     "jss-preset-default": "^10.6.0"
   },
   "peerDependencies": {
-    "@morfeo/web": "^0.1.3"
+    "@morfeo/web": "^0.1.4"
   },
   "devDependencies": {
-    "@morfeo/web": "^0.1.3"
+    "@morfeo/web": "^0.1.4"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/native/CHANGELOG.md
+++ b/packages/native/CHANGELOG.md
@@ -3,6 +3,29 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## 0.1.4 (2021-05-22)
+
+
+### Bug Fixes
+
+* readme files fix and licenses added ([c71286a](https://github.com/VLK-STUDIO/morfeo/tree/main/packages/native/commit/c71286acf948e65eacb5e0ac808cc9425d576351))
+
+
+### Features
+
+* all css props mapped and styled components package improved ([c3771c6](https://github.com/VLK-STUDIO/morfeo/tree/main/packages/native/commit/c3771c64b02fc7bbfa6137bff70d1acae8e7932a))
+* cache and benchmarks ([aa360dd](https://github.com/VLK-STUDIO/morfeo/tree/main/packages/native/commit/aa360ddfb44ce2be66a0513783ddec1ff6b42e09))
+* flatted parser.resolve method ([5ce2c10](https://github.com/VLK-STUDIO/morfeo/tree/main/packages/native/commit/5ce2c101097b7ab28d985b108ee079e07f8bacce))
+* jss package and fix to native test ([30b6c4a](https://github.com/VLK-STUDIO/morfeo/tree/main/packages/native/commit/30b6c4a1551ee7feb66a31c48f38e1841a6ebdb2))
+* native package ([356cbd6](https://github.com/VLK-STUDIO/morfeo/tree/main/packages/native/commit/356cbd6de9084be2a02db90073fb8fcbb8191641))
+* readme files added to all the packages ([819e60b](https://github.com/VLK-STUDIO/morfeo/tree/main/packages/native/commit/819e60bb536be471f373c8d3f7cbd5b331c1434c))
+* styled components for web ([e5dee4c](https://github.com/VLK-STUDIO/morfeo/tree/main/packages/native/commit/e5dee4c65277089b282b3ba7da3696451c559b83))
+* web styled-components package introduced ([a7677c3](https://github.com/VLK-STUDIO/morfeo/tree/main/packages/native/commit/a7677c3a8f3c561101b0eba0b87e7fa983677cf9))
+
+
+
+
+
 ## 0.1.3 (2021-05-21)
 
 

--- a/packages/native/package.json
+++ b/packages/native/package.json
@@ -5,7 +5,7 @@
     "email": "mauro@vlkstudio.com"
   },
   "private": false,
-  "version": "0.1.3",
+  "version": "0.1.4",
   "license": "MIT",
   "main": "build/index.js",
   "module": "build/index.js",
@@ -23,7 +23,7 @@
     "watch": "tsc -w"
   },
   "dependencies": {
-    "@morfeo/core": "^0.1.3",
+    "@morfeo/core": "^0.1.4",
     "@types/react-native": "^0.64.4"
   },
   "peerDependencies": {

--- a/packages/spec/CHANGELOG.md
+++ b/packages/spec/CHANGELOG.md
@@ -3,6 +3,30 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## 0.1.4 (2021-05-22)
+
+
+### Bug Fixes
+
+* fixed typing of  packages ([57267c5](https://github.com/VLK-STUDIO/morfeo/tree/main/packages/spec/commit/57267c5f904cbeece433e7bb2573fd9d7a4b3fd4))
+* readme files fix and licenses added ([c71286a](https://github.com/VLK-STUDIO/morfeo/tree/main/packages/spec/commit/c71286acf948e65eacb5e0ac808cc9425d576351))
+
+
+### Features
+
+* added pubish config to packages ([23241fc](https://github.com/VLK-STUDIO/morfeo/tree/main/packages/spec/commit/23241fcb4a1ef76615661e5b8e9e4ed53060b912))
+* all css props mapped and styled components package improved ([c3771c6](https://github.com/VLK-STUDIO/morfeo/tree/main/packages/spec/commit/c3771c64b02fc7bbfa6137bff70d1acae8e7932a))
+* cache and benchmarks ([aa360dd](https://github.com/VLK-STUDIO/morfeo/tree/main/packages/spec/commit/aa360ddfb44ce2be66a0513783ddec1ff6b42e09))
+* hooks package added ([0637789](https://github.com/VLK-STUDIO/morfeo/tree/main/packages/spec/commit/0637789d23e12bb3dfb295039e92d2a4f815927a))
+* native package ([356cbd6](https://github.com/VLK-STUDIO/morfeo/tree/main/packages/spec/commit/356cbd6de9084be2a02db90073fb8fcbb8191641))
+* readme files added to all the packages ([819e60b](https://github.com/VLK-STUDIO/morfeo/tree/main/packages/spec/commit/819e60bb536be471f373c8d3f7cbd5b331c1434c))
+* styled components for web ([e5dee4c](https://github.com/VLK-STUDIO/morfeo/tree/main/packages/spec/commit/e5dee4c65277089b282b3ba7da3696451c559b83))
+* web styled-components package introduced ([a7677c3](https://github.com/VLK-STUDIO/morfeo/tree/main/packages/spec/commit/a7677c3a8f3c561101b0eba0b87e7fa983677cf9))
+
+
+
+
+
 ## 0.1.3 (2021-05-21)
 
 

--- a/packages/spec/package.json
+++ b/packages/spec/package.json
@@ -5,7 +5,7 @@
     "email": "mauro@vlkstudio.com"
   },
   "private": false,
-  "version": "0.1.3",
+  "version": "0.1.4",
   "license": "MIT",
   "main": "build/index.js",
   "module": "build/index.js",

--- a/packages/styled-components-web/CHANGELOG.md
+++ b/packages/styled-components-web/CHANGELOG.md
@@ -3,6 +3,28 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## 0.1.4 (2021-05-22)
+
+
+### Bug Fixes
+
+* readme files fix and licenses added ([c71286a](https://github.com/VLK-STUDIO/morfeo/tree/main/packages/styled-components-web/commit/c71286acf948e65eacb5e0ac808cc9425d576351))
+
+
+### Features
+
+* all css props mapped and styled components package improved ([c3771c6](https://github.com/VLK-STUDIO/morfeo/tree/main/packages/styled-components-web/commit/c3771c64b02fc7bbfa6137bff70d1acae8e7932a))
+* cache and benchmarks ([aa360dd](https://github.com/VLK-STUDIO/morfeo/tree/main/packages/styled-components-web/commit/aa360ddfb44ce2be66a0513783ddec1ff6b42e09))
+* flatted parser.resolve method ([5ce2c10](https://github.com/VLK-STUDIO/morfeo/tree/main/packages/styled-components-web/commit/5ce2c101097b7ab28d985b108ee079e07f8bacce))
+* introucing svelte package and sandbox ([0e8e9e2](https://github.com/VLK-STUDIO/morfeo/tree/main/packages/styled-components-web/commit/0e8e9e22f38576730c73442714c1a611847d9bc7))
+* readme files added to all the packages ([819e60b](https://github.com/VLK-STUDIO/morfeo/tree/main/packages/styled-components-web/commit/819e60bb536be471f373c8d3f7cbd5b331c1434c))
+* styled components for web ([e5dee4c](https://github.com/VLK-STUDIO/morfeo/tree/main/packages/styled-components-web/commit/e5dee4c65277089b282b3ba7da3696451c559b83))
+* web styled-components package introduced ([a7677c3](https://github.com/VLK-STUDIO/morfeo/tree/main/packages/styled-components-web/commit/a7677c3a8f3c561101b0eba0b87e7fa983677cf9))
+
+
+
+
+
 ## 0.1.3 (2021-05-21)
 
 

--- a/packages/styled-components-web/package.json
+++ b/packages/styled-components-web/package.json
@@ -5,7 +5,7 @@
     "email": "mauro@vlkstudio.com"
   },
   "private": false,
-  "version": "0.1.3",
+  "version": "0.1.4",
   "license": "MIT",
   "main": "build/index.js",
   "module": "build/index.js",
@@ -22,14 +22,14 @@
     "watch": "tsc -w"
   },
   "peerDependencies": {
-    "@morfeo/web": "^0.1.3",
+    "@morfeo/web": "^0.1.4",
     "csstype": "^3.0.8",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "styled-components": "^5.2.3"
   },
   "devDependencies": {
-    "@morfeo/web": "^0.1.3"
+    "@morfeo/web": "^0.1.4"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/svelte/CHANGELOG.md
+++ b/packages/svelte/CHANGELOG.md
@@ -3,6 +3,24 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## 0.1.4 (2021-05-22)
+
+
+### Bug Fixes
+
+* readme files fix and licenses added ([c71286a](https://github.com/VLK-STUDIO/morfeo/tree/main/packages/svelte/commit/c71286acf948e65eacb5e0ac808cc9425d576351))
+
+
+### Features
+
+* introucing svelte package and sandbox ([0e8e9e2](https://github.com/VLK-STUDIO/morfeo/tree/main/packages/svelte/commit/0e8e9e22f38576730c73442714c1a611847d9bc7))
+* readme files added to all the packages ([819e60b](https://github.com/VLK-STUDIO/morfeo/tree/main/packages/svelte/commit/819e60bb536be471f373c8d3f7cbd5b331c1434c))
+* update callback to jss function ([6218907](https://github.com/VLK-STUDIO/morfeo/tree/main/packages/svelte/commit/62189076da38078df33796fb16576b13ecdeeb85))
+
+
+
+
+
 ## 0.1.3 (2021-05-21)
 
 

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -5,7 +5,7 @@
     "email": "mauro@vlkstudio.com"
   },
   "private": false,
-  "version": "0.1.3",
+  "version": "0.1.4",
   "license": "MIT",
   "main": "build/index.js",
   "module": "build/index.js",
@@ -21,13 +21,13 @@
     "watch": "tsc -w"
   },
   "dependencies": {
-    "@morfeo/jss": "^0.1.3"
+    "@morfeo/jss": "^0.1.4"
   },
   "peerDependencies": {
-    "@morfeo/web": "^0.1.3"
+    "@morfeo/web": "^0.1.4"
   },
   "devDependencies": {
-    "@morfeo/web": "^0.1.3"
+    "@morfeo/web": "^0.1.4"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/web/CHANGELOG.md
+++ b/packages/web/CHANGELOG.md
@@ -3,6 +3,29 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## 0.1.4 (2021-05-22)
+
+
+### Bug Fixes
+
+* fixed typing of  packages ([57267c5](https://github.com/VLK-STUDIO/morfeo/tree/main/packages/web/commit/57267c5f904cbeece433e7bb2573fd9d7a4b3fd4))
+* readme files fix and licenses added ([c71286a](https://github.com/VLK-STUDIO/morfeo/tree/main/packages/web/commit/c71286acf948e65eacb5e0ac808cc9425d576351))
+
+
+### Features
+
+* added pubish config to packages ([23241fc](https://github.com/VLK-STUDIO/morfeo/tree/main/packages/web/commit/23241fcb4a1ef76615661e5b8e9e4ed53060b912))
+* flatted parser.resolve method ([5ce2c10](https://github.com/VLK-STUDIO/morfeo/tree/main/packages/web/commit/5ce2c101097b7ab28d985b108ee079e07f8bacce))
+* hooks package added ([0637789](https://github.com/VLK-STUDIO/morfeo/tree/main/packages/web/commit/0637789d23e12bb3dfb295039e92d2a4f815927a))
+* native package ([356cbd6](https://github.com/VLK-STUDIO/morfeo/tree/main/packages/web/commit/356cbd6de9084be2a02db90073fb8fcbb8191641))
+* readme files added to all the packages ([819e60b](https://github.com/VLK-STUDIO/morfeo/tree/main/packages/web/commit/819e60bb536be471f373c8d3f7cbd5b331c1434c))
+* styled components for web ([e5dee4c](https://github.com/VLK-STUDIO/morfeo/tree/main/packages/web/commit/e5dee4c65277089b282b3ba7da3696451c559b83))
+* web styled-components package introduced ([a7677c3](https://github.com/VLK-STUDIO/morfeo/tree/main/packages/web/commit/a7677c3a8f3c561101b0eba0b87e7fa983677cf9))
+
+
+
+
+
 ## 0.1.3 (2021-05-21)
 
 

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -5,7 +5,7 @@
     "email": "mauro@vlkstudio.com"
   },
   "private": false,
-  "version": "0.1.3",
+  "version": "0.1.4",
   "license": "MIT",
   "main": "build/index.js",
   "module": "build/index.js",
@@ -20,7 +20,7 @@
     "watch": "tsc -w"
   },
   "dependencies": {
-    "@morfeo/core": "^0.1.3"
+    "@morfeo/core": "^0.1.4"
   },
   "peerDependencies": {
     "csstype": "^3.0.8"


### PR DESCRIPTION
 - includes README files and a fix to the @morfeo/core package that now
   includes "tslib" as a peerDependency