### PR TITLE
fix(devtool): crash by navigating to a font slice if the fonts slice has no font

### DIFF
--- a/devtool/src/_shared/components/Slices/Fonts/Detail/index.tsx
+++ b/devtool/src/_shared/components/Slices/Fonts/Detail/index.tsx
@@ -48,7 +48,7 @@ export const Detail: React.FC<Props> = ({ main = 'fonts' }) => {
   const themeFonts = useThemeSlice('fonts')
 
   const firstFont = useMemo(() => {
-    const fontArray = Object.keys(themeFonts)
+    const fontArray = Object.keys(themeFonts || {})
     return fontArray[0] as Font
   }, [themeFonts])
 

--- a/devtool/src/_shared/components/Slices/Fonts/General.tsx
+++ b/devtool/src/_shared/components/Slices/Fonts/General.tsx
@@ -23,7 +23,7 @@ const ItemCard: React.FC<ItemProps> = ({ property, value }) => {
   const themeFonts = useTheme().fonts;
 
   const firstFont = useMemo(() => {
-    const fontArray = Object.keys(themeFonts)
+    const fontArray = Object.keys(themeFonts || {})
     return fontArray[0] as keyof Fonts
   }, [themeFonts])
 


### PR DESCRIPTION
## Fix

The devtool was crashing by navigating to a font slice if in the `fonts` slice there are no fonts.

## Types of changes

Null check

- [x ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices applies)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/VLK-STUDIO/morfeo/blob/main/CONTRIBUTING.md) doc
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments
It closes issue #97 

