### PR TITLE
fix: publish workflows

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,8 +20,16 @@ jobs:
            git update-index --assume-unchanged $i
          done
          git update-index --assume-unchanged lerna.json
-      - run: npm run reset
       # Publish to npm
-      - run: npx lerna publish from-package --yes --no-verify-access
+      - run: npm run publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      # Setup .npmrc file to publish to GitHub Packages
+      - uses: actions/setup-node@v2
+        with:
+          registry-url: 'https://npm.pkg.github.com'
+          scope: '@morfeo'
+      # Publish to GitHub Packages
+      - run: npm run publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "test": "jest --updateSnapshot",
     "test:watch": "jest --watch --updateSnapshot",
     "test:coverage": "jest --verbose --coverage --updateSnapshot",
-    "publish": "npm run reset && npx lerna publish from-package --yes",
+    "publish": "npm run reset && npx lerna publish from-package --yes --no-verify-access",
     "version": "npx lerna version patch --no-push --no-git-tag-version --conventional-commits",
     "version:minor": "npx lerna version minor --no-push --no-git-tag-version --conventional-commits",
     "postversion": "ts-node scripts/version.ts",

--- a/packages/cli/.gitignore
+++ b/packages/cli/.gitignore
@@ -1,5 +1,6 @@
 *-debug.log
 *-error.log
+oclif.manifest.json
 /.nyc_output
 /dist
 /lib

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -47,7 +47,6 @@
     "morfeo",
     "design",
     "system",
-    "morfeo",
     "builder",
     "morfeo-js"
   ],
@@ -61,9 +60,9 @@
     ]
   },
   "scripts": {
-    "postpack": "rm -f oclif.manifest.json",
-    "prepack": "rm -rf lib && tsc -b && oclif-dev manifest && oclif-dev readme",
-    "version": "oclif-dev readme && git add README.md"
+    "build": "rm -rf lib && tsc -b",
+    "prepack": "npm run build && oclif-dev manifest && oclif-dev readme",
+    "version": "oclif-dev readme"
   },
   "types": "lib/index.d.ts",
   "publishConfig": {

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "composite": true,
+    "composite": false,
     "outDir": "lib",
     "rootDir": "src",
     "module": "commonjs",


### PR DESCRIPTION
 - Closes #106
 - Re-Introduced publish to Github packages

## Proposed changes

Remove `composite` flag from the `tsconfig.json` file inside the package `@morfeo/cli` that was causing the pubilsh workflow failure.
Re-Introduced the publish to github packages (this will be more an experiment for the next release).

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/VLK-STUDIO/morfeo/blob/main/CONTRIBUTING.md) doc
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
