### PR TITLE
fix: Closes #113

### DIFF
--- a/packages/cli/src/utils/loggers.ts
+++ b/packages/cli/src/utils/loggers.ts
@@ -39,6 +39,6 @@ export function logFooter(watching?: boolean) {
   );
   cli.url(
     'morfeo.dev',
-    italic.gray('https://morfeo.dev/docs/Features/morfeo-cli'),
+    italic.gray('https://morfeo.dev/docs/Features/CLI/morfeo-cli-introduction'),
   );
 }

--- a/packages/core/src/morfeo.ts
+++ b/packages/core/src/morfeo.ts
@@ -78,7 +78,7 @@ function createMorfeo() {
     newTheme: Parameters<typeof theme.set>[0],
   ) {
     themes[themeName] = deepMerge(themes[themeName] || {}, newTheme) as Theme;
-    if (!current) {
+    if (!current || current === themeName) {
       useTheme(themeName);
     }
   }

--- a/packages/core/src/theme/createTheme.ts
+++ b/packages/core/src/theme/createTheme.ts
@@ -4,7 +4,7 @@ import { deepMerge } from '../utils';
 type ThemeListener = (theme: Theme) => void;
 
 export function createTheme() {
-  let context: Theme = {} as any;
+  let context: Theme = undefined as any;
   let listeners: Record<string | number, ThemeListener> = {};
 
   function get() {
@@ -55,7 +55,7 @@ export function createTheme() {
   function set(theme: {
     [TK in ThemeKey]?: Partial<Theme[TK]>;
   }) {
-    context = deepMerge(context, theme) as Theme;
+    context = deepMerge(context || {}, theme) as Theme;
     callListeners();
   }
 

--- a/packages/hooks/src/MorfeoContext.tsx
+++ b/packages/hooks/src/MorfeoContext.tsx
@@ -1,4 +1,4 @@
 import { Theme } from '@morfeo/core';
 import { createContext } from 'react';
 
-export const MorfeoContext = createContext<Theme>({} as Theme);
+export const MorfeoContext = createContext<Theme>(undefined as any);

--- a/packages/hooks/src/useTheme.ts
+++ b/packages/hooks/src/useTheme.ts
@@ -1,4 +1,4 @@
-import { ThemeKey, Theme } from '@morfeo/core';
+import { ThemeKey, Theme, morfeo } from '@morfeo/core';
 import { useContext } from 'react';
 import { MorfeoContext } from './MorfeoContext';
 
@@ -9,7 +9,7 @@ import { MorfeoContext } from './MorfeoContext';
  * @returns the theme object
  */
 export function useTheme() {
-  return useContext(MorfeoContext);
+  return useContext(MorfeoContext) || morfeo.getTheme();
 }
 
 /**

--- a/packages/hooks/tests/useTheme.test.ts
+++ b/packages/hooks/tests/useTheme.test.ts
@@ -1,3 +1,4 @@
+import { renderHook as baseRenderHook } from '@testing-library/react-hooks';
 import { morfeo } from '@morfeo/core';
 import { useTheme, useThemeSlice, useThemeValue } from '../src';
 import { renderHook } from './customRenderer';
@@ -38,5 +39,13 @@ describe('useThemeValue', () => {
     const { result } = renderHook(() => useThemeValue('colors', 'primary'));
 
     expect(result.current).toEqual(THEME.colors.primary);
+  });
+});
+
+describe('useTheme without provider', () => {
+  test('should return the theme even if the app is not wrapped with `MorfeoProvider`', () => {
+    const { result } = baseRenderHook(() => useTheme());
+
+    expect(result.current).toEqual(THEME);
   });
 });

--- a/packages/styled-components-web/src/styled.ts
+++ b/packages/styled-components-web/src/styled.ts
@@ -1,4 +1,11 @@
-import { parsers, component, Theme, Style, Component } from '@morfeo/react';
+import {
+  parsers,
+  component,
+  Theme,
+  Style,
+  Component,
+  theme,
+} from '@morfeo/react';
 import styled, { ThemedStyledFunction } from 'styled-components';
 import { MorfeoStyled, ComponentTag } from './types';
 
@@ -77,6 +84,9 @@ const morfeoStyledHandler: MorfeoStyled = ((tag: ComponentTag) => {
 
 export const morfeoStyled = new Proxy(morfeoStyledHandler, {
   get(target, prop, receiver) {
+    if (theme.get() === undefined) {
+      theme.set({});
+    }
     const result = target(prop as any);
     if (result) {
       return result;

--- a/packages/styled-components-web/tests/ThemeProvider.test.tsx
+++ b/packages/styled-components-web/tests/ThemeProvider.test.tsx
@@ -4,12 +4,13 @@ import renderer from 'react-test-renderer';
 import { ThemeProvider } from '../src';
 import 'jest-styled-components';
 
+beforeAll(() => {
+  theme.set({} as any);
+});
+
 describe('ThemeProvider', () => {
   test('should match the snapshot', () => {
     const tree = renderer.create(<ThemeProvider />).toJSON();
-    renderer.act(() => {
-      theme.set({} as any);
-    });
     expect(tree).toMatchSnapshot();
   });
 });

--- a/packages/styled-components-web/tests/styled.test.tsx
+++ b/packages/styled-components-web/tests/styled.test.tsx
@@ -1,49 +1,59 @@
 import React from 'react';
-import { theme } from '@morfeo/react';
+import { morfeo } from '@morfeo/react';
 import morfeoStyled from '../src';
 import renderer from 'react-test-renderer';
 import 'jest-styled-components';
 
-beforeAll(() => {
-  theme.set({
-    colors: {
-      primary: 'black',
-      secondary: 'white',
-    },
-    components: {
-      Box: {
-        tag: 'div',
-        style: { color: 'primary' },
-        props: { 'aria-label': 'default box' },
-        variants: {
-          primary: {
-            tag: 'button',
-            style: { color: 'secondary' },
-            props: { 'aria-label': 'primary button', type: 'submit' },
-          },
-          secondary: {
-            style: { bg: 'secondary' },
-            props: { 'aria-label': 'secondary button', type: 'submit' },
-          },
+const theme = {
+  colors: {
+    primary: 'black',
+    secondary: 'white',
+  },
+  components: {
+    Box: {
+      tag: 'div',
+      style: { color: 'primary' },
+      props: { 'aria-label': 'default box' },
+      variants: {
+        primary: {
+          tag: 'button',
+          style: { color: 'secondary' },
+          props: { 'aria-label': 'primary button', type: 'submit' },
+        },
+        secondary: {
+          style: { bg: 'secondary' },
+          props: { 'aria-label': 'secondary button', type: 'submit' },
         },
       },
-      Text: {
-        tag: 'p',
-        style: {},
-        props: { variant: 'h1' },
-        variants: {
-          h1: {
-            tag: 'h1',
-            style: { fontWeight: 'bold' },
-          },
+    },
+    Text: {
+      tag: 'p',
+      style: {},
+      props: { variant: 'h1' },
+      variants: {
+        h1: {
+          tag: 'h1',
+          style: { fontWeight: 'bold' },
         },
       },
-      Incomplete: {},
     },
-  } as any);
+    Incomplete: {},
+  },
+} as any;
+
+describe('morfeoStyled - when morfeo was not set', () => {
+  test('should render the component', () => {
+    const Component = morfeoStyled.div({});
+    const tree = renderer.create(<Component>Test</Component>).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
 });
 
 describe('morfeoStyled', () => {
+  beforeAll(() => {
+    morfeo.setTheme('default', theme);
+  });
+
   test('should work as the default styled interface', () => {
     const Button = morfeoStyled.button`
       color: red;


### PR DESCRIPTION
## Proposed changes

Closes #113 

To fix the bug #113 I made some changes to the initial value of the singleton `theme`:

 - the internal state is `undefined` by default instead of an empty object
 - In this way the value inside the context if `MorfeoProvider` is not set this is undefined now, aand the hook useTheme will return morfeo.getTheme() instead, so the provider is no more mandatory.

By doing this I had to make another fix to @morfeo/styled-components-web too to ensure the existence of a theme, even if it's simply an empty object.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/VLK-STUDIO/morfeo/blob/main/CONTRIBUTING.md) doc
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules

