### PR TITLE
fix: #116 extends components from theme

### DIFF
--- a/packages/core/src/parsers/components.ts
+++ b/packages/core/src/parsers/components.ts
@@ -7,7 +7,7 @@ export function components({ value, style }: ParserParams<'componentName'>) {
     return {};
   }
   const componentStyle = component(value, variant).getStyle();
-  return globalThis.__MORFEO_PARSERS.resolve(componentStyle || {});
+  return globalThis.__MORFEO_PARSERS.resolve(componentStyle);
 }
 
 export const componentsParses = {

--- a/packages/core/tests/parsers/components.test.ts
+++ b/packages/core/tests/parsers/components.test.ts
@@ -95,4 +95,39 @@ describe('components', () => {
     const result = parsers.resolve({ componentName: 'Typography' as any });
     expect(result).toEqual({ color: '#000', backgroundColor: '#e3e3e3' });
   });
+
+  test('should extends the style of another component variant', () => {
+    theme.reset();
+    theme.set({
+      ...THEME,
+      components: {
+        ...THEME.components,
+        Typography: {
+          style: {
+            color: 'secondary',
+          },
+          variants: {
+            h1: {
+              style: {
+                color: 'primary',
+              },
+            },
+            h2: {
+              style: {
+                componentName: 'Typography',
+                variant: 'h1',
+              },
+            },
+          },
+        },
+      } as any,
+    });
+
+    const result = parsers.resolve({
+      componentName: 'Typography' as any,
+      variant: 'h2',
+    });
+
+    expect(result).toEqual({ color: THEME.colors.primary });
+  });
 });

--- a/packages/core/tests/theme/component.test.ts
+++ b/packages/core/tests/theme/component.test.ts
@@ -31,6 +31,32 @@ const defaultTheme = {
         },
       },
     },
+    VariantCycle: {
+      style: {
+        color: 'secondary',
+        bg: 'primary',
+      },
+      variants: {
+        one: {
+          style: {
+            color: 'primary',
+          },
+        },
+        two: {
+          style: {
+            componentName: 'VariantCycle',
+            variant: 'one',
+            bg: 'secondary',
+          },
+        },
+        three: {
+          style: {
+            componentName: 'VariantCycle',
+            variant: 'two',
+          },
+        },
+      },
+    },
   },
 } as const;
 
@@ -84,5 +110,13 @@ describe('component', () => {
     expect(props).toEqual(mergedConfig.props);
     expect(style).toEqual(mergedConfig.style);
     expect(variants).toEqual(mergedVariants);
+  });
+
+  test('should be possible to use componentName and variant as component style', () => {
+    const twoStyle = component('VariantCycle' as any, 'three').getStyle();
+    expect(twoStyle).toEqual({
+      color: 'primary',
+      bg: 'secondary',
+    });
   });
 });


### PR DESCRIPTION
## Proposed changes

Closes #116 

To fix the issue explained in the bug #116 I had to change the way we handle the resolution of the style of the components.
The rule was something like:
 - If there is no variant -> return the style of the base component
 - If there is a variant -> merge the style of the base component with the variant and return this merged object.

This is exactly what we want as a result, but there is another rule Morfeo follows:
 - the style obtained from the component has always less priority than all the other properties

This is made to ensure that you can always overwrite the default behaviour of a component.
For instance a style like:
```json
{
  "componentName": "Button",
  "variant": "primary",
  "bg": "background"
}
```
Will always have `bg: 'background'`, no matter whats inside the primary variant of the Button component.

The problem explained in the bug #116  is a particular case when this rule seems to conflict with the first set of rules, if a variant extends in its style another component or variant, the resulted style will be the `merge` of this styles:

```javascript
const theme = {
  ...rest,
  components: {
    Component: {
       style: {
         color: 'text',
       },
       variants: {
           one: {
              style: {
                color: 'primary',
              }
           },
           two: {
               style: {
                  componentName: 'Component',
                  variant: 'one',
                }
            },
        },
    },
  }
};

cost componentStyle = component('Component', 'two').getStyle();
//  { componentName: 'Component', variant: 'one', color: 'text' }
```

It's clear that **technically** in this case `componentName: 'Component', variant: 'one',` should overwrite `color: 'text'` once this style will be resolved, but this will never happen because the component style has less priority than `color`.

To fix this bug my solution is to always be sure that if `component('componeName', 'variant').getStyle()`is called always return a style without `componentName` and `variant` and so `getStyle` should care about resolving these properties in the right way.

In the previous example, `component().getStyle` will now return:

`{ color: 'primary' }`

Because it resolve recursively `componentName` and `variant` until it contains only base properties.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/VLK-STUDIO/morfeo/blob/main/CONTRIBUTING.md) doc
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
